### PR TITLE
fix: don't need less files when they are also transpiled to css

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -87,7 +87,7 @@ gulp.task('post-transpile', ['transpile'], function () {
     .pipe(replace(/\.html',/g, ".html'),"))
     .pipe(replace(/\.html'/g, ".html')"))
     .pipe(replace(/styleUrls: \[/g, "styles: [require("))
-    .pipe(replace(/\.less']/g, ".less').toString()]"))
+    .pipe(replace(/\.less']/g, ".css').toString()]"))
     .pipe(gulp.dest(function (file) {
       return file.base; // because of Angular 2's encapsulation, it's natural to save the css where the less-file was
     }));
@@ -105,7 +105,6 @@ gulp.task('build-library',
     'transpile-less',
     'transpile',
     'post-transpile',
-    'copy-less',
     'copy-html',
     'copy-static-assets'
   ]);
@@ -119,13 +118,6 @@ gulp.task('transpile', function () {
 gulp.task('copy-css', ['transpile'], function () {
   return copyToDist([
     'src/**/*.css'
-  ]);
-});
-
-// require in case it is put inside ngx-launcher
-gulp.task('copy-less', function () {
-  return copyToDist([
-    'src/**/*.less'
   ]);
 });
 
@@ -166,7 +158,7 @@ gulp.task('watch', ['build-library', 'copy-watch-all'], function () {
   gulp.watch([appSrc + '/app/**/*.ts', '!' + appSrc + '/app/**/*.spec.ts'], ['transpile', 'post-transpile', 'copy-watch']).on('change', function (e) {
     console.log('TypeScript file ' + e.path + ' has been changed. Compiling.');
   });
-  gulp.watch([appSrc + '/app/**/*.less'], ['copy-less']).on('change', function (e) {
+  gulp.watch([appSrc + '/app/**/*.less']).on('change', function (e) {
     console.log(e.path + ' has been changed. Updating.');
     // transpileLESS(e.path);
     updateWatchDist();


### PR DESCRIPTION
it shouldn't matter what css framework was used to build this module using it shouldn't affect the webpack file of the user.