### PR TITLE
fix(dependencies): update dependencies to use ranges

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -126,7 +126,7 @@ Step 1: Run `npm run watch:library` in the source directory::
 This will build fabric8-analytics-dep-editor as a library and then set up a watch task to
 rebuild any ts, html and scss files you change.
 
-Step 2: Run `npm link <path to fabric8-stack-analysis-ui>/dist-watch`::
+Step 2: Run `npm link <path to fabric8-stack-analysis-ui>/dist-watch --production`::
 In the webapp into which you are embedding. This will create a symlink from
 `node_modules/fabric8-analytics-dep-editor` to the `dist-watch` directory and install that
 symlinked node module into your webapp.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fabric8-analytics-dependency-editor",
-  "version": "0.0.1-development",
+  "version": "0.0.0-development",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -703,16 +703,6 @@
       "dev": true,
       "requires": {
         "zone.js": "0.8.5"
-      }
-    },
-    "JSONStream": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.2.tgz",
-      "integrity": "sha1-wQI3G27Dp887hHygDCC7D85Mbeo=",
-      "dev": true,
-      "requires": {
-        "jsonparse": "1.3.1",
-        "through": "2.3.8"
       }
     },
     "abbrev": {
@@ -2734,8 +2724,8 @@
       "integrity": "sha512-jaAP61py+ISMF3/n3yIiIuY5h6mJlucOqawu5mLB1HaQADLvg/y5UB3pT7HSucZJan34lp7+7ylQPfbKEGmxrA==",
       "dev": true,
       "requires": {
-        "JSONStream": "1.3.2",
         "is-text-path": "1.0.1",
+        "JSONStream": "1.3.2",
         "lodash": "4.17.4",
         "meow": "4.0.0",
         "split2": "2.2.0",
@@ -8278,6 +8268,16 @@
       "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
       "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
       "dev": true
+    },
+    "JSONStream": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.2.tgz",
+      "integrity": "sha1-wQI3G27Dp887hHygDCC7D85Mbeo=",
+      "dev": true,
+      "requires": {
+        "jsonparse": "1.3.1",
+        "through": "2.3.8"
+      }
     },
     "jsprim": {
       "version": "1.4.1",
@@ -15500,6 +15500,15 @@
       "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
       "dev": true
     },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
+    },
     "string-width": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
@@ -15536,15 +15545,6 @@
         "define-properties": "1.1.2",
         "es-abstract": "1.11.0",
         "function-bind": "1.1.1"
-      }
-    },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
       }
     },
     "stringstream": {

--- a/package.json
+++ b/package.json
@@ -74,22 +74,19 @@
     "npm": ">= 5.3.0"
   },
   "dependencies": {
-    "c3": "0.4.18",
-    "ngx-bootstrap": "1.9.3",
-    "ngx-modal": "0.0.29"
+    "c3": "^0.4.18",
+    "ngx-bootstrap": "^1.9.3",
+    "ngx-modal": "^0.0.29"
   },
   "peerDependencies": {
-    "@angular/core": "4.4.6",
-    "@angular/common": "4.4.6",
-    "@angular/forms": "4.4.6",
-    "@angular/http": "4.4.6",
-    "@angular/compiler": "4.4.6",
-    "@angular/compiler-cli": "4.4.6",
-    "@angular/platform-browser": "4.4.6",
-    "@angular/platform-browser-dynamic": "4.4.6",
-    "@angular/router": "4.4.6",
-    "rxjs": "5.5.2",
-    "zone.js": "0.8.5"
+    "@angular/core": "^4.4.6",
+    "@angular/common": "^4.4.6",
+    "@angular/forms": "^4.4.6",
+    "@angular/http": "^4.4.6",
+    "@angular/platform-browser": "^4.4.6",
+    "@angular/platform-browser-dynamic": "^4.4.6",
+    "@angular/router": "^4.4.6",
+    "rxjs": "^5.5.2"
   },
   "devDependencies": {
     "@angular/animations": "4.4.6",


### PR DESCRIPTION
Related to openshiftio/openshift.io#3686

Use ranges for dependencies to avoid duplicate library inclusions.

`npm link --production` must be used to omit installation of `devDependencies` when linking.