### PR TITLE
feat(group-categories): groups multiple categories into one for a single dependency

### DIFF
--- a/src/app/add-dependency/add-dependency.component.html
+++ b/src/app/add-dependency/add-dependency.component.html
@@ -117,7 +117,7 @@
             </div>
             <div (click)="handleCategoryClick(tags?.packages[0]?.category, i + 1)" [ngClass]="{'list-group-item tag-list-item-n': true, 'active-category': categoriesStore[i + 1]?.isOpened}" *ngFor="let tags of categoryResult; let i = index">
               <div class="list-view-pf-actions">
-                <label class="mix-label">{{tags.pkg_count}}</label>
+                <label class="mix-label">{{getPackageCount(tags.packages)}}</label>
               </div>
               <div class="list-view-pf-main-info" *ngIf="tags.packages">
                 <div class="list-view-pf-body">
@@ -155,7 +155,7 @@
                         </div>
                         <div>
                           <div>
-                            <div class="tag-border">{{master.category}}</div>
+                            <div *ngFor="let cat of master?.category" class="tag-border">{{cat}}</div>
                             <div class="grouped col-sm-4" *ngIf="master.grouped">Added</div>
                           </div>
                         </div>

--- a/src/app/add-dependency/add-dependency.pipe.ts
+++ b/src/app/add-dependency/add-dependency.pipe.ts
@@ -10,7 +10,7 @@ export class FilterPipe implements PipeTransform {
             if (input.indexOf('$$') !== -1) {
                 let cat = input.split('$$')[0];
                 if (cat !== 'All') {
-                    return value.filter((i: any) => i.category === cat);
+                    return value.filter((i: any) => i.category.indexOf(cat) !== -1);
                 }
                 return value;
             }

--- a/src/app/dependency-editor/dependency-editor.component.ts
+++ b/src/app/dependency-editor/dependency-editor.component.ts
@@ -208,7 +208,6 @@ export class DependencyEditorComponent implements OnInit, OnChanges, OnDestroy {
   private setLicenseData(result: ResultInformationModel) {
     this.licenseData = result.user_stack_info.license_analysis;
     this.allLicenses = result.user_stack_info.distinct_licenses;
-    debugger;
     this.service.licenseSubscription.next(new LicenseUIModel(this.licenseData, null, this.allLicenses));
   }
 

--- a/src/app/license/license.component.ts
+++ b/src/app/license/license.component.ts
@@ -138,7 +138,6 @@ export class LicenseComponent implements OnInit, OnChanges {
   }
 
   ngOnChanges(changes: SimpleChanges) {
-    debugger;
     this.handleChanges();
   }
 


### PR DESCRIPTION
Tracks: openshiftio/openshift.io#3863

Description:

Currently, the flow shows a modal with all the dependencies listed individually. A single dependency falling into multiple categories would be listed multiple times.
This PR handles and groups them together showing dependency just once and list all the categories that it belongs to as a group next to another.