### PR TITLE
Add catalog-info.yaml config file

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: fabric8-analytics-dependency-editor
+  annotations:
+    github.com/project-slug: fabric8-analytics/fabric8-analytics-dependency-editor
+spec:
+  type: other
+  lifecycle: unknown
+  owner: user:development/guest


### PR DESCRIPTION
This pull request adds a **Backstage entity metadata file**
to this repository so that the component can
be added to the [software catalog](http://localhost:3000/catalog).
After this pull request is merged, the component will become available.
For more information, read an [overview of the Backstage software catalog](https://backstage.io/docs/features/software-catalog/).
View the import job in your app [here](http://localhost:3000/bulk-import/repositories?repository=https://github.com/fabric8-analytics/fabric8-analytics-dependency-editor&defaultBranch=master).